### PR TITLE
README: Changed clone URL to HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ run:
 
 Additionally, you can install the bootstrapper by cloning the git repo:
 
-    git clone git@github.com:kendo-labs/kendo-bootstrapper.git
+    git clone https://github.com/kendo-labs/kendo-bootstrapper.git
     cd kendo-bootstrapper
     npm install
     node bin/start.js


### PR DESCRIPTION
This is a small change to the readme to instruct people to clone via HTTPS instead of SSH. I think SSH can be more difficult to use if your system is not setup correctly, so defaulting to HTTPS is probably easier.
